### PR TITLE
[mvc1-4] MVC 프레임워크 만들기

### DIFF
--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/ModelView.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/ModelView.java
@@ -5,8 +5,8 @@ import java.util.Map;
 
 public class ModelView {
 
-    private String viewName;
-    private Map<String, Object> model = new HashMap<>();
+    private String viewName; // 논리 view 이름
+    private Map<String, Object> model = new HashMap<>(); // 모델 객체
 
     public ModelView(String viewName) {
         this.viewName = viewName;

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/MyView.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/MyView.java
@@ -20,9 +20,9 @@ public class MyView {
     }
 
     public void render(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        modelToRequestAttribute(model, request);
+        modelToRequestAttribute(model, request); // 모델에 담긴 정보를 모두 꺼내서 http servlet request setAttribute에 넣어준다.
         RequestDispatcher dispatcher = request.getRequestDispatcher(viewPath);
-        dispatcher.forward(request, response);
+        dispatcher.forward(request, response); // dispatcher를 통해 jsp로 이동한다.
     }
 
     private static void modelToRequestAttribute(Map<String, Object> model, HttpServletRequest request) {

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v3/ControllerV3.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v3/ControllerV3.java
@@ -6,5 +6,5 @@ import java.util.Map;
 
 public interface ControllerV3 {
 
-    ModelView process(Map<String, String> paramMap);
+    ModelView process(Map<String, String> paramMap); // 서블릿에 종속적이지 않다.
 }

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v3/FrontControllerServletV3.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v3/FrontControllerServletV3.java
@@ -41,11 +41,12 @@ public class FrontControllerServletV3 extends HttpServlet {
 
         // paramMap
 
-        Map<String, String> paramMap = createParamMap(request);
+        Map<String, String> paramMap = createParamMap(request); // 파라미터를 모두 뽑는다.
         ModelView mv = controller.process(paramMap);
 
-        String viewName = mv.getViewName();// 논리이름 new-form
-        MyView view = viewResolver(viewName);
+        // 뷰 리졸버는 컨트롤러가 반환한 논리이름을 물리이름으로 변경하고, 실제 물리 경로가 있는 MyView 객체를 반환한다.
+        String viewName = mv.getViewName(); // 논리이름 반환 ex) new-form
+        MyView view = viewResolver(viewName); // 물리이름 반환 ex) /WEB-INF/views/new-form.jsp
         
         view.render(mv.getModel(), request, response);
 
@@ -53,7 +54,7 @@ public class FrontControllerServletV3 extends HttpServlet {
 
     private static MyView viewResolver(String viewName) {
         return new MyView("/WEB-INF/views/" + viewName + ".jsp");
-    }
+    } // 물리 경로가 변경되더라도 컨트롤러를 건드릴 필요없이, 이 부분의 코드만 고치면 된다.
 
     private static Map<String, String> createParamMap(HttpServletRequest request) {
         Map<String, String> paramMap = new HashMap<>();

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/ControllerV4.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/ControllerV4.java
@@ -1,0 +1,14 @@
+package hello.servlet.web.frontcontroller.v4;
+
+import java.util.Map;
+
+public interface ControllerV4 {
+    /**
+     *
+     * @param paramMap
+     * @param model
+     * @return viewName
+     */
+    String process(Map<String, String> paramMap,Map<String, Object> model);
+    // 모델을 파라미터로 넘긴다.
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/FrontControllerServletV4.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/FrontControllerServletV4.java
@@ -1,0 +1,59 @@
+package hello.servlet.web.frontcontroller.v4;
+
+import hello.servlet.web.frontcontroller.MyView;
+import hello.servlet.web.frontcontroller.v4.controller.MemberFormControllerV4;
+import hello.servlet.web.frontcontroller.v4.controller.MemberListControllerV4;
+import hello.servlet.web.frontcontroller.v4.controller.MemberSaveControllerV4;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet(name = "frontControllerServletV4", urlPatterns = "/front-controller/v4/*")
+public class FrontControllerServletV4 extends HttpServlet {
+
+    private Map<String, ControllerV4> controllerMap = new HashMap<>();
+
+    public FrontControllerServletV4() {
+        controllerMap.put("/front-controller/v4/members/new-form", new MemberFormControllerV4());
+        controllerMap.put("/front-controller/v4/members/save", new MemberSaveControllerV4());
+        controllerMap.put("/front-controller/v4/members", new MemberListControllerV4());
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+
+        ControllerV4 controller = controllerMap.get(requestURI);
+
+        if (controller == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        Map<String, String> paramMap = createParamMap(request);
+        Map<String, Object> model = new HashMap<>(); // 모델 객체를 프론트 컨트롤러에서 생성해서 넘겨준다.
+
+        String viewName = controller.process(paramMap, model);
+
+        MyView view = viewResolver(viewName);
+        view.render(model, request, response);
+    }
+
+    private Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+        return paramMap;
+    }
+
+    private MyView viewResolver(String viewName) {
+        return new MyView("/WEB-INF/views/" + viewName + ".jsp");
+    }
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/controller/MemberFormControllerV4.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/controller/MemberFormControllerV4.java
@@ -1,0 +1,12 @@
+package hello.servlet.web.frontcontroller.v4.controller;
+
+import hello.servlet.web.frontcontroller.v4.ControllerV4;
+
+import java.util.Map;
+
+public class MemberFormControllerV4 implements ControllerV4 {
+    @Override
+    public String process(Map<String, String> paramMap, Map<String, Object> model) {
+        return "new-form";
+    }
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/controller/MemberListControllerV4.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/controller/MemberListControllerV4.java
@@ -1,0 +1,21 @@
+package hello.servlet.web.frontcontroller.v4.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.MemberRepository;
+import hello.servlet.web.frontcontroller.v4.ControllerV4;
+
+import java.util.List;
+import java.util.Map;
+
+public class MemberListControllerV4 implements ControllerV4 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public String process(Map<String, String> paramMap, Map<String, Object> model) {
+        List<Member> members = memberRepository.findAll();
+
+        model.put("members", members);
+        return "members";
+    }
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/controller/MemberSaveControllerV4.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v4/controller/MemberSaveControllerV4.java
@@ -1,0 +1,24 @@
+package hello.servlet.web.frontcontroller.v4.controller;
+
+import hello.servlet.domain.member.Member;
+import hello.servlet.domain.member.MemberRepository;
+import hello.servlet.web.frontcontroller.v4.ControllerV4;
+
+import java.util.Map;
+
+public class MemberSaveControllerV4 implements ControllerV4 {
+
+    private final MemberRepository memberRepository = MemberRepository.getInstance();
+
+    @Override
+    public String process(Map<String, String> paramMap, Map<String, Object> model) {
+        String username = paramMap.get("username");
+        int age = Integer.parseInt(paramMap.get("age"));
+
+        Member member = new Member(username, age);
+        memberRepository.save(member);
+
+        model.put("member", member);
+        return "save-result";
+    }
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/FrontControllerServletV5.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/FrontControllerServletV5.java
@@ -1,0 +1,76 @@
+package hello.servlet.web.frontcontroller.v5;
+
+import hello.servlet.web.frontcontroller.ModelView;
+import hello.servlet.web.frontcontroller.MyView;
+import hello.servlet.web.frontcontroller.v3.controller.MemberFormControllerV3;
+import hello.servlet.web.frontcontroller.v3.controller.MemberListControllerV3;
+import hello.servlet.web.frontcontroller.v3.controller.MemberSaveControllerV3;
+import hello.servlet.web.frontcontroller.v5.adapter.ControllerV3HandlerAdapter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@WebServlet(name = "frontControllerServletV5", urlPatterns = "/front-controller/v5/*")
+public class FrontControllerServletV5 extends HttpServlet {
+
+    private final Map<String, Object> handlerMappingMap = new HashMap<>();
+    // 매핑 정보의 값이 ControllerV3 , ControllerV4 같은 인터페이스에서 아무 값이나 받을 수 있는 Object 로 변경되었다.
+    private final List<MyHandlerAdapter> handlerAdapters = new ArrayList<>();
+
+    public FrontControllerServletV5() {
+        initHandlerMappingMap(); // 핸들러 매핑 초기화
+        initHandlerAdapters(); // 어댑터 초기화
+    }
+
+    private void initHandlerMappingMap() {
+        handlerMappingMap.put("/front-controller/v5/v3/members/new-form", new MemberFormControllerV3());
+        handlerMappingMap.put("/front-controller/v5/v3/members/save", new MemberSaveControllerV3());
+        handlerMappingMap.put("/front-controller/v5/v3/members", new MemberListControllerV3());
+    }
+
+    private void initHandlerAdapters() {
+        handlerAdapters.add(new ControllerV3HandlerAdapter());
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        Object handler = getHandler(request);
+        if (handler == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        MyHandlerAdapter adapter = getHandlerAdapter(handler);
+        ModelView mv = adapter.handle(request, response, handler);
+
+        MyView view = viewResolver(mv.getViewName());
+        view.render(mv.getModel(), request, response);
+    }
+
+    private Object getHandler(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        return handlerMappingMap.get(requestURI);
+    }
+
+    private MyHandlerAdapter getHandlerAdapter(Object handler) {
+        for (MyHandlerAdapter adapter : handlerAdapters) {
+            if (adapter.supports(handler)) { // handler 를 처리할 수 있는 어댑터를 찾는다.
+                return adapter;
+            }
+        }
+
+        throw new IllegalArgumentException("handler adapter를 찾을 수 없습니다. handler=" + handler);
+    }
+
+    private MyView viewResolver(String viewName) {
+        return new MyView("/WEB-INF/views/" + viewName + ".jsp");
+    }
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/FrontControllerServletV5.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/FrontControllerServletV5.java
@@ -5,7 +5,11 @@ import hello.servlet.web.frontcontroller.MyView;
 import hello.servlet.web.frontcontroller.v3.controller.MemberFormControllerV3;
 import hello.servlet.web.frontcontroller.v3.controller.MemberListControllerV3;
 import hello.servlet.web.frontcontroller.v3.controller.MemberSaveControllerV3;
+import hello.servlet.web.frontcontroller.v4.controller.MemberFormControllerV4;
+import hello.servlet.web.frontcontroller.v4.controller.MemberListControllerV4;
+import hello.servlet.web.frontcontroller.v4.controller.MemberSaveControllerV4;
 import hello.servlet.web.frontcontroller.v5.adapter.ControllerV3HandlerAdapter;
+import hello.servlet.web.frontcontroller.v5.adapter.ControllerV4HandlerAdapter;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -34,10 +38,16 @@ public class FrontControllerServletV5 extends HttpServlet {
         handlerMappingMap.put("/front-controller/v5/v3/members/new-form", new MemberFormControllerV3());
         handlerMappingMap.put("/front-controller/v5/v3/members/save", new MemberSaveControllerV3());
         handlerMappingMap.put("/front-controller/v5/v3/members", new MemberListControllerV3());
+
+        handlerMappingMap.put("/front-controller/v5/v4/members/new-form", new MemberFormControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members/save", new MemberSaveControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members", new MemberListControllerV4());
     }
 
     private void initHandlerAdapters() {
+
         handlerAdapters.add(new ControllerV3HandlerAdapter());
+        handlerAdapters.add(new ControllerV4HandlerAdapter());
     }
 
     @Override

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/MyHandlerAdapter.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/MyHandlerAdapter.java
@@ -1,0 +1,19 @@
+package hello.servlet.web.frontcontroller.v5;
+
+import hello.servlet.web.frontcontroller.ModelView;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public interface MyHandlerAdapter {
+
+    boolean supports(Object handler); // 어댑터가 해당 컨트롤러(핸들러)를 처리할 수 있는지 판단한다.
+
+    // 어댑터는 실제 컨트롤러를 호출하고, 그 결과로 ModelView를 반환해야 한다.
+    // 실제 컨트롤러가 ModelView를 반환하지 못하면, 어뎁터가 ModelView를 직접 생성해서라도 반환해야 한다.
+    // 이전에는 프론트 컨트롤러가 실제 컨트롤러를 호출했지만, 이제는 이 어댑터를 통해서 실제 컨트롤러가 호출된다.
+
+    ModelView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException;
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV3HandlerAdapter.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV3HandlerAdapter.java
@@ -1,0 +1,35 @@
+package hello.servlet.web.frontcontroller.v5.adapter;
+
+import hello.servlet.web.frontcontroller.ModelView;
+import hello.servlet.web.frontcontroller.v3.ControllerV3;
+import hello.servlet.web.frontcontroller.v5.MyHandlerAdapter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControllerV3HandlerAdapter implements MyHandlerAdapter {
+    @Override
+    public boolean supports(Object handler) {
+        return (handler instanceof ControllerV3);
+    }
+
+    @Override
+    public ModelView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException {
+        ControllerV3 controller = (ControllerV3) handler; // handler를 컨트롤러 V3로 변환한 다음에 V3 형식에 맞도록 호출한다.
+        Map<String, String> paramMap = createParamMap(request);
+
+        ModelView mv = controller.process(paramMap);
+        return mv;
+    }
+
+    private Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+        return paramMap;
+    }
+}

--- a/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV4HandlerAdapter.java
+++ b/minseo/mvc1/servlet/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV4HandlerAdapter.java
@@ -1,0 +1,46 @@
+package hello.servlet.web.frontcontroller.v5.adapter;
+
+import hello.servlet.web.frontcontroller.ModelView;
+import hello.servlet.web.frontcontroller.v4.ControllerV4;
+import hello.servlet.web.frontcontroller.v5.MyHandlerAdapter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControllerV4HandlerAdapter implements MyHandlerAdapter {
+    @Override
+    public boolean supports(Object handler) {
+        return (handler instanceof ControllerV4); // handler 가 ControllerV4 인 경우에만 처리하는 어댑터
+    }
+
+    @Override
+    public ModelView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException {
+
+        // handler를 ControllerV4로 캐스팅 하고, paramMap, model을 만들어서 해당 컨트롤러를 호출한다.
+        ControllerV4 controller = (ControllerV4) handler;
+
+        Map<String, String> paramMap = createParamMap(request);
+        Map<String, Object> model = new HashMap<>();
+
+        // 어댑터가 호출하는 ControllerV4 는 뷰의 이름을 반환한다.
+        // 그런데 어댑터는 뷰의 이름이 아니라 ModelView 를 만들어서 반환해야 한다.
+        String viewName = controller.process(paramMap, model);
+
+        // ControllerV4는 뷰의 이름을 반환했지만, 어댑터는 이것을 ModelView로 만들어서 형식을 맞추어 반환한다.
+        ModelView mv = new ModelView(viewName);
+        mv.setModel(model);
+
+        return mv;
+    }
+
+    private Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+        return paramMap;
+    }
+}


### PR DESCRIPTION
### v1: 프론트 컨트롤러를 도입
기존 구조를 최대한 유지하면서 프론트 컨트롤러를 도입
  
<img width="501" alt="스크린샷 2023-12-21 오후 4 26 32" src="https://github.com/spring-study-1/spring/assets/83651335/5f9fb0ab-e2e1-42ca-8152-62ac965c14dc">

* 프론트 컨트롤러를 제외한 나머지 컨트롤러는 서블릿을 사용하지 않아도 된다.
* url 매핑을 해서 클라이언트 요청이 오면 WAS 서버로 처음 요청을 보내는 곳이 서블릿인데, 이 역할을 FrontController가 대신 해준다.

### v2: View 분류
단순 반복 되는 뷰 로직 분리

<img width="582" alt="스크린샷 2023-12-21 오후 4 31 06" src="https://github.com/spring-study-1/spring/assets/83651335/7e3f9554-96b7-4910-a9b3-ecd87e83e47e">

* ControllerV2의 반환 타입이 MyView 이므로 프론트 컨트롤러는 컨트롤러의 호출 결과로 MyView 를 반환 받는다.
* view.render() 를 호출하면 forward 로직을 수행해서 JSP가 실행된다.

### v3: Model 추가 서블릿 종속성 제거
서블릿 종속성 제거, 뷰 이름 중복 제거

<img width="517" alt="스크린샷 2023-12-21 오후 4 33 48" src="https://github.com/spring-study-1/spring/assets/83651335/a01bb2cc-c8da-43a7-ab28-e3c51238afad">

* 요청 파라미터 정보는 자바의 Map으로 대신 넘기도록 하면 지금 구조에서는 컨트롤러가 서블릿 기술을 몰라도 동작할 수 있다.
* 컨트롤러는 뷰의 논리 이름을 반환하고, 실제 물리 위치의 이름은 프론트 컨트롤러에서 처리하도록 단순화한다.

### v4: 단순하고 실용적인 컨트롤러 v3와 거의 비슷
구현 입장에서 ModelView를 직접 생성해서 반환하지 않도록 편리한 인터페이스 제공

<img width="512" alt="스크린샷 2023-12-21 오후 4 35 51" src="https://github.com/spring-study-1/spring/assets/83651335/ced76bed-d8e8-48c1-8f9a-9369b9c0a75d">

* 이번 버전은 인터페이스에 ModelView가 없다. model 객체는 파라미터로 전달되기 때문에 그냥 사용하면 되고, 결과로 뷰의 논리 이름만 반환해주면 된다.

### v5: 유연한 컨트롤러 어댑터 도입
어댑터를 추가해서 프레임워크를 유연하고 확장성 있게 설계

<img width="516" alt="스크린샷 2023-12-21 오후 4 37 16" src="https://github.com/spring-study-1/spring/assets/83651335/e85722e4-0920-4799-9b93-739d5dddee5b">

* 핸들러 어댑터: 중간에 어댑터 역할을 하는 어댑터가 추가되었는데 이름이 핸들러 어댑터이다. 여기서 어댑터 역할을 해주는 덕분에 다양한 종류의 컨트롤러를 호출할 수 있다.
* 핸들러: 컨트롤러의 이름을 더 넓은 범위인 핸들러로 변경했다. 그 이유는 이제 어댑터가 있기 때문에 꼭 컨트롤러의 개념 뿐만 아니라 어떠한 것이든 해당하는 종류의 어댑터만 있으면 다 처리할 수 있기 때문이다.